### PR TITLE
Completed full diagram views and archimate 3.0 support

### DIFF
--- a/lib/archimate/data_model/connection.rb
+++ b/lib/archimate/data_model/connection.rb
@@ -117,17 +117,9 @@ module Archimate
         []
       end
 
-      # TODO: Is this true for all or only Archi models?
       def absolute_position
-        # offset = bounds || Archimate::DataModel::Bounds.zero
-        offset = Archimate::DataModel::Bounds.zero
-        el = parent.parent
-        while el.respond_to?(:bounds) && el.bounds
-          bounds = el.bounds
-          offset = offset.with(x: (offset.x || 0) + (bounds.x || 0), y: (offset.y || 0) + (bounds.y || 0))
-          el = el.parent.parent
-        end
-        offset
+        pt = Svg::Path.new(self).midpoint
+        Bounds.new(x: pt.x, y: pt.y, width: 0, height: 0)
       end
 
       def replace_item_with(item, replacement)

--- a/lib/archimate/data_model/elements.rb
+++ b/lib/archimate/data_model/elements.rb
@@ -115,15 +115,6 @@ module Archimate
         end
       end
 
-      class Meaning < Element
-        CLASSIFICATION = :passive_structure
-        LAYER = Layers::Business
-
-        def initialize(args)
-          super
-        end
-      end
-
       class Product < Element
         CLASSIFICATION = :passive_structure
         LAYER = Layers::Business
@@ -134,15 +125,6 @@ module Archimate
       end
 
       class Representation < Element
-        CLASSIFICATION = :passive_structure
-        LAYER = Layers::Business
-
-        def initialize(args)
-          super
-        end
-      end
-
-      class Value < Element
         CLASSIFICATION = :passive_structure
         LAYER = Layers::Business
 
@@ -491,6 +473,15 @@ module Archimate
         end
       end
 
+      class Meaning < Element
+        CLASSIFICATION = :passive_structure
+        LAYER = Layers::Motivation
+
+        def initialize(args)
+          super
+        end
+      end
+
       class Outcome < Element
         CLASSIFICATION = :active_structure
         LAYER = Layers::Motivation
@@ -520,6 +511,15 @@ module Archimate
 
       class Stakeholder < Element
         CLASSIFICATION = :active_structure
+        LAYER = Layers::Motivation
+
+        def initialize(args)
+          super
+        end
+      end
+
+      class Value < Element
+        CLASSIFICATION = :passive_structure
         LAYER = Layers::Motivation
 
         def initialize(args)

--- a/lib/archimate/data_model/view_node.rb
+++ b/lib/archimate/data_model/view_node.rb
@@ -92,8 +92,9 @@ module Archimate
       # @return [Element, NilClass]
       model_attr :element, writable: true, comparison_attr: :id, default: nil, also_reference: [:diagram]
       # Archi format, selects the shape of element (for elements that can have two or more shapes)
+      # A nil value indicates the standard representation, a value of "1" indicates the alternate
       # @!attribute [r] child_type
-      # @return [Int, NilClass]
+      # @return [String, NilClass]
       model_attr :child_type, default: nil
 
       # @!attribute [r] diagram

--- a/lib/archimate/svg/archimate.css
+++ b/lib/archimate/svg/archimate.css
@@ -56,7 +56,6 @@ table.properties>caption {
     float: right;
     height: 20px;
     width: 20px;
-    /*border: 1px solid red;*/
 }
 
 .archimate-icon {
@@ -115,8 +114,8 @@ table.properties>caption {
 }
 
 .archimate-motivation-background {
-    fill: #fecdfe;
-    stroke: #b18fb1;
+    fill: #cccdfd;
+    stroke: #8e8fb1;
 }
 
 .archimate-motivation2-background {
@@ -147,6 +146,12 @@ table.properties>caption {
 .archimate-group-background {
     fill: #d2d7d7;
     stroke: #939696;
+}
+
+.archimate-grouping-background {
+    fill: #ffffff;
+    stroke: #b2b2b2;
+    stroke-dasharray: 8,4;
 }
 
 .archimate-sticky-background {
@@ -225,9 +230,6 @@ table.properties>caption {
     stroke-dasharray: 5, 3;
 }
 
-/*, .archimate-association {
-}
-*/
 .archimate-triggering {
     marker-end: url(#archimate-filled-arrow);
 }
@@ -236,7 +238,3 @@ table.properties>caption {
     marker-end: url(#archimate-filled-arrow);
     stroke-dasharray: 3, 3;
 }
-
-/*.archimate-default-connection {
-}
-*/

--- a/lib/archimate/svg/entity.rb
+++ b/lib/archimate/svg/entity.rb
@@ -46,6 +46,7 @@ module Archimate
       autoload :Gap, 'archimate/svg/entity/gap'
       autoload :Goal, 'archimate/svg/entity/goal'
       autoload :Group, 'archimate/svg/entity/group'
+      autoload :Grouping, 'archimate/svg/entity/grouping'
       autoload :ImplementationEvent, 'archimate/svg/entity/implementation_event'
       autoload :InfrastructureEvent, 'archimate/svg/entity/infrastructure_event'
       autoload :InfrastructureFunction, 'archimate/svg/entity/infrastructure_function'

--- a/lib/archimate/svg/entity/application_component.rb
+++ b/lib/archimate/svg/entity/application_component.rb
@@ -4,13 +4,20 @@ module Archimate
   module Svg
     module Entity
       # TODO: support alternate appearance
-      class ApplicationComponent < BaseEntity
+      class ApplicationComponent < RectEntity
         def initialize(child, bounds_offset)
           super
+          @badge = "#archimate-app-component-badge"
         end
 
         def entity_shape(xml, bounds)
-          component_path(xml, bounds)
+          case child.child_type
+          when "1"
+            super
+          else
+            component_path(xml, bounds)
+            @badge = nil
+          end
         end
 
         def component_path(xml, bounds)

--- a/lib/archimate/svg/entity/constraint.rb
+++ b/lib/archimate/svg/entity/constraint.rb
@@ -6,7 +6,6 @@ module Archimate
       class Constraint < MotivationEntity
         def initialize(child, bounds_offset)
           super
-          @background_class = "archimate-motivation2-background"
           @badge = "#archimate-constraint-badge"
         end
       end

--- a/lib/archimate/svg/entity/contract.rb
+++ b/lib/archimate/svg/entity/contract.rb
@@ -7,6 +7,15 @@ module Archimate
         def initialize(child, bounds_offset)
           super
         end
+
+        def entity_shape(xml, bounds)
+          calc_text_bounds(bounds)
+          xml.g(class: background_class) do
+            xml.rect(x: bounds.left, y: bounds.top, width: bounds.width, height: bounds.height, class: background_class, style: shape_style)
+            xml.rect(x: bounds.left, y: bounds.top, width: bounds.width, height: @margin, class: "archimate-decoration")
+            xml.rect(x: bounds.left, y: bounds.top + bounds.height - @margin, width: bounds.width, height: @margin, class: "archimate-decoration")
+          end
+        end
       end
     end
   end

--- a/lib/archimate/svg/entity/data_entity.rb
+++ b/lib/archimate/svg/entity/data_entity.rb
@@ -6,7 +6,7 @@ module Archimate
       class DataEntity < BaseEntity
         def initialize(child, bounds_offset)
           super
-          @margin = 10
+          @margin = 8
         end
 
         def calc_text_bounds(_bounds)

--- a/lib/archimate/svg/entity/device.rb
+++ b/lib/archimate/svg/entity/device.rb
@@ -12,7 +12,7 @@ module Archimate
 
         def entity_shape(xml, bounds)
           case child.child_type
-          when 1
+          when "1"
             @badge = "#archimate-device-badge"
             node_path(xml, bounds)
           else

--- a/lib/archimate/svg/entity/event_entity.rb
+++ b/lib/archimate/svg/entity/event_entity.rb
@@ -3,13 +3,28 @@
 module Archimate
   module Svg
     module Entity
-      class EventEntity < BaseEntity
+      class EventEntity < RoundedRectEntity
+        def initialize(child, bounds_offset)
+          super
+          @badge = "#archimate-event-badge"
+        end
+
         def entity_shape(xml, bounds)
+          case child.child_type
+          when "1"
+            @badge = nil
+            event_path(xml, bounds)
+          else
+            super
+          end
+        end
+
+        def event_path(xml, bounds)
           notch_x = 18
           notch_height = bounds.height / 2.0
           event_width = bounds.width * 0.85
           rx = 17
-          calc_text_bounds(notch_x)
+          calc_event_text_bounds(notch_x)
           xml.path(
             d: [
               "M", bounds.left, bounds.top,
@@ -23,12 +38,14 @@ module Archimate
           )
         end
 
-        def calc_text_bounds(notch_x)
+        def calc_event_text_bounds(notch_x)
           bounds = @text_bounds
-          @text_bounds = DataModel::Bounds.new(bounds.to_h.merge(
-            x: bounds.left + notch_x * 0.80,
-            width: bounds.width - notch_x
-          ))
+          @text_bounds = DataModel::Bounds.new(
+            bounds.to_h.merge(
+              x: bounds.left + notch_x * 0.80,
+              width: bounds.width - notch_x
+            )
+          )
         end
       end
     end

--- a/lib/archimate/svg/entity/grouping.rb
+++ b/lib/archimate/svg/entity/grouping.rb
@@ -1,12 +1,13 @@
+
 # frozen_string_literal: true
 
 module Archimate
   module Svg
     module Entity
-      class Group < BaseEntity
+      class Grouping < BaseEntity
         def initialize(child, bounds_offset)
           super
-          @background_class = "archimate-group-background"
+          @background_class = "archimate-grouping-background"
         end
 
         def entity_shape(xml, bounds)
@@ -19,20 +20,13 @@ module Archimate
             class: background_class,
             style: shape_style
           )
-          xml.rect(
-            x: bounds.left,
-            y: bounds.top,
-            width: bounds.width / 2.0,
-            height: group_header_height,
+          xml.path(
+            d: ["M", bounds.left, bounds.top + group_header_height - 1,
+                "v", -(group_header_height - 1),
+                "h", bounds.width / 2,
+                "v", group_header_height - 1].map(&:to_s).join(" "),
             class: background_class,
             style: shape_style
-          )
-          xml.rect(
-            x: bounds.left,
-            y: bounds.top,
-            width: bounds.width / 2.0,
-            height: group_header_height,
-            class: "archimate-decoration"
           )
           @text_bounds = DataModel::Bounds.new(bounds.to_h.merge(height: group_header_height))
           @text_align = "left"

--- a/lib/archimate/svg/entity/interface_entity.rb
+++ b/lib/archimate/svg/entity/interface_entity.rb
@@ -11,7 +11,7 @@ module Archimate
 
         def entity_shape(xml, bounds)
           case child.child_type
-          when 1
+          when "1"
             @badge = nil
             elipse_path(xml, bounds)
           else

--- a/lib/archimate/svg/entity/node.rb
+++ b/lib/archimate/svg/entity/node.rb
@@ -14,7 +14,7 @@ module Archimate
 
         def entity_shape(xml, bounds)
           case child.child_type
-          when 1
+          when "1"
             @badge_bounds = DataModel::Bounds.new(
               x: bounds.right - 25,
               y: bounds.top + 5,

--- a/lib/archimate/svg/entity/outcome.rb
+++ b/lib/archimate/svg/entity/outcome.rb
@@ -6,7 +6,6 @@ module Archimate
       class Outcome < MotivationEntity
         def initialize(child, bounds_offset)
           super
-          @background_class = "archimate-motivation2-background"
           @badge = "#archimate-outcome-badge"
         end
       end

--- a/lib/archimate/svg/entity/principle.rb
+++ b/lib/archimate/svg/entity/principle.rb
@@ -6,7 +6,6 @@ module Archimate
       class Principle < MotivationEntity
         def initialize(child, bounds_offset)
           super
-          @background_class = "archimate-motivation2-background"
           @badge = "#archimate-principle-badge"
         end
       end

--- a/lib/archimate/svg/entity/process_entity.rb
+++ b/lib/archimate/svg/entity/process_entity.rb
@@ -11,7 +11,7 @@ module Archimate
 
         def entity_shape(xml, bounds)
           case child.child_type
-          when 1
+          when "1"
             @badge = nil
             process_path(xml, bounds)
           else

--- a/lib/archimate/svg/entity/requirement.rb
+++ b/lib/archimate/svg/entity/requirement.rb
@@ -6,7 +6,6 @@ module Archimate
       class Requirement < MotivationEntity
         def initialize(child, bounds_offset)
           super
-          @background_class = "archimate-motivation2-background"
           @badge = "#archimate-requirement-badge"
         end
       end

--- a/lib/archimate/svg/entity/service_entity.rb
+++ b/lib/archimate/svg/entity/service_entity.rb
@@ -3,12 +3,11 @@
 module Archimate
   module Svg
     module Entity
-      class ServiceEntity < BaseEntity
-        include Rect
-
+      class ServiceEntity < RoundedRectEntity
         def initialize(child, bounds_offset)
           super
           bounds = child.bounds
+          @badge = "#archimate-service-badge"
           @text_bounds = DataModel::Bounds.new(
             x: bounds.left + 7,
             y: bounds.top + 5,
@@ -19,17 +18,11 @@ module Archimate
 
         def entity_shape(xml, bounds)
           case child.child_type
-          when 1
-            @badge_bounds = DataModel::Bounds.new(
-              x: bounds.right - 25,
-              y: bounds.top + 5,
-              width: 20,
-              height: 20
-            )
-            @badge = "#archimate-service-badge"
-            rect_path(xml, bounds)
-          else
+          when "1"
             service_path(xml, bounds)
+            @badge = nil
+          else
+            super
           end
         end
 

--- a/lib/archimate/svg/svg_template.svg.erb
+++ b/lib/archimate/svg/svg_template.svg.erb
@@ -80,8 +80,8 @@
     <symbol id="archimate-collaboration-badge" class="archimate-badge"  viewBox="0 0 20 15" preserveAspectRatio="xMaxYMin meet">
       <path d="m7.5 14 a 6.5 6.5 0 0 1 0 -13 a 6.5 6.5 0 0 1 0 13 m 5 0 a 6.5 6.5 0 0 1 0 -13 a 6.5 6.5 0 0 1 0 13" style="fill:inherit;stroke:inherit"/>
     </symbol>
-    <symbol id="archimate-communication-badge" class="archimate-badge"  viewBox="0 0 20 15">
-      <path d="m7.5 -1 l -6.5 6.5 l 6.5 6.5 m 5 -13 l 6.5 6.5 l -6.5 6.5 m -7 -6.5 h 3 m 3 0 h 3" style="fill:inherit;stroke:inherit"/>
+    <symbol id="archimate-communication-path-badge" class="archimate-badge"  viewBox="0 0 20 15">
+      <path d="m7.5 -1 l -6.5 6.5 l 6.5 6.5 m 5 -13 l 6.5 6.5 l -6.5 6.5 m -7 -6.5 h 2 m 1.5 0 h 2 m 1.5 0 h 2" style="fill:inherit;stroke:inherit"/>
     </symbol>
     <symbol id="archimate-constraint-badge" class="archimate-badge"  viewBox="0 0 20 15">
       <path d="m6 -1 h 13 l -5 10 h -13 z m 4 0 l -5 10" style="fill:inherit;stroke:inherit"/>
@@ -92,6 +92,9 @@
     </symbol>
     <symbol id="archimate-driver-badge" class="archimate-badge"  viewBox="0 0 20 15">
       <path d="m17.5 6.5 a 6.5 6.5 0 0 0 -13 0 a 6.5 6.5 0 0 0 13 0 m 2 0 h -17 m 8.5 -8.5 v 17 m -6.01 -2.49 l 12.02 -12.02 m 0 12.02 l -12.02 -12.02" style="fill:inherit;stroke:inherit"/>
+    </symbol>
+    <symbol id="archimate-event-badge" class="archimate-badge"  viewBox="0 0 20 20">
+      <path d="m1 1 a 8 6.5 0 0 1 0 12 h 12 a 6 5.5 0 0 0 0 -12 z" style="fill:inherit;stroke:inherit"/>
     </symbol>
     <symbol id="archimate-function-badge" class="archimate-badge"  viewBox="0 0 20 20" preserveAspectRatio="xMaxYMin meet">
       <path d="m7 15 l 0 -9 l 6 -5 l 6 5 l 0 9 l -6 -6 z" style="fill:none;stroke:inherit"/>
@@ -116,6 +119,11 @@
     </symbol>
     <symbol id="archimate-network-badge" class="archimate-badge"  viewBox="0 0 20 15">
       <path d="m9 9.5 a 2.5 2.5 0 0 0 -5 0 a 2.5 2.5 0 0 0 5 0 m -2 -2.5 l 1 -3 m 0.5 0 a 2.5 2.5 0 0 0 0 -5 a 2.5 2.5 0 0 0 0 5 m 2 -2.5 h 3.5 a 2.5 2.5 0 0 0 5 0 a 2.5 2.5 0 0 0 -5 0 m 2 2.5 l -1 3 m -0.5 0 a 2.5 2.5 0 0 0 0 5 a 2.5 2.5 0 0 0 0 -5 m -2 2.5 h -3.5" style="fill:inherit;stroke:inherit"/>
+    </symbol>
+    <symbol id="archimate-app-component-badge" class="archimate-badge" viewBox="0 0 20 20">
+      <path d="m6 4 v -3 h 12 v 17 h -12 v -3 m 0 -4 v -3" style="fill:inherit;stroke:inherit;"/>
+      <rect x="1" y="4" width="9" height="4" style="fill:inherit;stroke:inherit;"/>
+      <rect x="1" y="11" width="9" height="4" style="fill:inherit;stroke:inherit;"/>
     </symbol>
     <symbol id="archimate-node-badge" class="archimate-badge" viewBox="0 0 20 20">
       <path d="M1 19 v -15 l 3 -3 h 15 v 15 l -3 3 z M 16 19 v -15 l 3 -3 m -3 3 h -15" style="fill:none;stroke:inherit;stroke-linejoin:miter;"/>

--- a/test/archimate/svg/entity/application_component_test.rb
+++ b/test/archimate/svg/entity/application_component_test.rb
@@ -17,7 +17,7 @@ module Archimate
         end
 
         def test_badge
-          assert_nil @subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-app-component-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/application_event_test.rb
+++ b/test/archimate/svg/entity/application_event_test.rb
@@ -17,7 +17,7 @@ module Archimate
 
         def test_badge
           subject = ApplicationEvent.new(@child, build_bounds)
-          assert_nil subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-event-badge", subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/application_service_test.rb
+++ b/test/archimate/svg/entity/application_service_test.rb
@@ -13,11 +13,12 @@ module Archimate
             ]
           )
           @child = @model.diagrams.first.nodes.first
+          @subject = ApplicationService.new(@child, build_bounds)
+
         end
 
         def test_badge
-          subject = ApplicationService.new(@child, build_bounds)
-          assert_nil subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-service-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/business_event_test.rb
+++ b/test/archimate/svg/entity/business_event_test.rb
@@ -17,7 +17,7 @@ module Archimate
         end
 
         def test_badge
-          assert_nil @subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-event-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/business_service_test.rb
+++ b/test/archimate/svg/entity/business_service_test.rb
@@ -17,7 +17,7 @@ module Archimate
         end
 
         def test_badge
-          assert_nil @subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-service-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/event_entity_test.rb
+++ b/test/archimate/svg/entity/event_entity_test.rb
@@ -17,7 +17,7 @@ module Archimate
         end
 
         def test_badge
-          assert_nil @subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-event-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/implementation_event_test.rb
+++ b/test/archimate/svg/entity/implementation_event_test.rb
@@ -17,7 +17,7 @@ module Archimate
         end
 
         def test_badge
-          assert_nil @subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-event-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/infrastructure_service_test.rb
+++ b/test/archimate/svg/entity/infrastructure_service_test.rb
@@ -17,7 +17,7 @@ module Archimate
         end
 
         def test_badge
-          assert_nil @subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-service-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/service_entity_test.rb
+++ b/test/archimate/svg/entity/service_entity_test.rb
@@ -17,7 +17,7 @@ module Archimate
         end
 
         def test_badge
-          assert_nil @subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-service-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/technology_event_test.rb
+++ b/test/archimate/svg/entity/technology_event_test.rb
@@ -17,7 +17,7 @@ module Archimate
         end
 
         def test_badge
-          assert_nil @subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-event-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/archimate/svg/entity/technology_service_test.rb
+++ b/test/archimate/svg/entity/technology_service_test.rb
@@ -17,7 +17,7 @@ module Archimate
         end
 
         def test_badge
-          assert_nil @subject.instance_variable_get(:@badge)
+          assert_equal "#archimate-service-badge", @subject.instance_variable_get(:@badge)
         end
       end
     end

--- a/test/examples/everything.archimate
+++ b/test/examples/everything.archimate
@@ -1,89 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archimate:model xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:archimate="http://www.archimatetool.com/archimate" name="everything" id="1d703f78" version="3.1.1">
+<archimate:model xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:archimate="http://www.archimatetool.com/archimate" name="everything" id="1d703f78" version="4.0.0">
+  <folder name="Strategy" id="3f9cbc15-8f1e-4d74-ac04-0f860c8e5fff" type="strategy"/>
   <folder name="Business" id="53819dd0" type="business">
-    <element xsi:type="archimate:BusinessActor" id="895b5ec5" name="Business Actor"/>
-    <element xsi:type="archimate:BusinessRole" id="d1a45f58" name="Business Role"/>
-    <element xsi:type="archimate:BusinessCollaboration" id="b6677ae1" name="Business Collaboration"/>
-    <element xsi:type="archimate:BusinessInterface" id="bc1ceb46" name="Business Interface"/>
-    <element xsi:type="archimate:BusinessFunction" id="15e2172c" name="Business Function"/>
-    <element xsi:type="archimate:BusinessProcess" id="70630355" name="Business Process"/>
-    <element xsi:type="archimate:BusinessEvent" id="cfffd652" name="Business Event"/>
-    <element xsi:type="archimate:BusinessInteraction" id="2a00fdf3" name="Business Interaction"/>
-    <element xsi:type="archimate:Product" id="f0090d70" name="Product"/>
-    <element xsi:type="archimate:Contract" id="03064f37" name="Contract"/>
-    <element xsi:type="archimate:BusinessService" id="b5dd94c9" name="Business Service"/>
-    <element xsi:type="archimate:Value" id="5ce14ef5" name="Value of some thing"/>
-    <element xsi:type="archimate:Meaning" id="b9d8f495" name="Meaning"/>
-    <element xsi:type="archimate:Representation" id="ab4c4726" name="Representation of us and all of that"/>
-    <element xsi:type="archimate:BusinessObject" id="e1616652" name="Business Object"/>
-    <element xsi:type="archimate:Location" id="d8440883" name="Location"/>
-    <element xsi:type="archimate:BusinessInterface" id="11af7615" name="Business Interface"/>
-    <element xsi:type="archimate:BusinessProcess" id="d393c534" name="Business Process"/>
-    <element xsi:type="archimate:BusinessService" id="495250a2" name="Business Service"/>
-    <element xsi:type="archimate:BusinessActor" id="f123a9d3" name="Business Actor"/>
-    <element xsi:type="archimate:BusinessProcess" id="e7c1a5f3" name="Business Process"/>
-    <element xsi:type="archimate:BusinessProcess" id="867c2f22" name="Business Process"/>
-    <element xsi:type="archimate:BusinessEvent" id="890c6b06" name="Business Event hello red fish blue fish"/>
+    <element xsi:type="archimate:BusinessActor" name="Business Actor" id="895b5ec5"/>
+    <element xsi:type="archimate:BusinessRole" name="Business Role" id="d1a45f58"/>
+    <element xsi:type="archimate:BusinessCollaboration" name="Business Collaboration" id="b6677ae1"/>
+    <element xsi:type="archimate:BusinessInterface" name="Business Interface" id="bc1ceb46"/>
+    <element xsi:type="archimate:BusinessFunction" name="Business Function" id="15e2172c"/>
+    <element xsi:type="archimate:BusinessProcess" name="Business Process" id="70630355"/>
+    <element xsi:type="archimate:BusinessEvent" name="Business Event" id="cfffd652"/>
+    <element xsi:type="archimate:BusinessInteraction" name="Business Interaction" id="2a00fdf3"/>
+    <element xsi:type="archimate:Product" name="Product" id="f0090d70"/>
+    <element xsi:type="archimate:Contract" name="Contract" id="03064f37"/>
+    <element xsi:type="archimate:BusinessService" name="Business Service" id="b5dd94c9"/>
+    <element xsi:type="archimate:Representation" name="Representation of us and all of that" id="ab4c4726"/>
+    <element xsi:type="archimate:BusinessObject" name="Business Object" id="e1616652"/>
+    <element xsi:type="archimate:BusinessInterface" name="Business Interface" id="11af7615"/>
+    <element xsi:type="archimate:BusinessProcess" name="Business Process" id="d393c534"/>
+    <element xsi:type="archimate:BusinessService" name="Business Service" id="495250a2"/>
+    <element xsi:type="archimate:BusinessActor" name="Business Actor" id="f123a9d3"/>
+    <element xsi:type="archimate:BusinessProcess" name="Business Process" id="e7c1a5f3"/>
+    <element xsi:type="archimate:BusinessProcess" name="Business Process" id="867c2f22"/>
+    <element xsi:type="archimate:BusinessEvent" name="Business Event hello red fish blue fish" id="890c6b06"/>
   </folder>
   <folder name="Application" id="256f89da" type="application">
-    <element xsi:type="archimate:ApplicationComponent" id="4e337ab3" name="Application Component"/>
-    <element xsi:type="archimate:ApplicationCollaboration" id="a3965597" name="Application Collaboration"/>
-    <element xsi:type="archimate:ApplicationInterface" id="72abc76d" name="Application Interface"/>
-    <element xsi:type="archimate:ApplicationService" id="e5504f30" name="Application Service"/>
-    <element xsi:type="archimate:ApplicationFunction" id="9b0af2d9" name="Application Function"/>
-    <element xsi:type="archimate:ApplicationInteraction" id="51eecad7" name="Application Interaction"/>
-    <element xsi:type="archimate:DataObject" id="75a63568" name="Data Object"/>
-    <element xsi:type="archimate:ApplicationComponent" id="2f331587" name="Application Component"/>
-    <element xsi:type="archimate:ApplicationInterface" id="8b0269a0" name="Application Interface"/>
-    <element xsi:type="archimate:ApplicationService" id="c50ea139" name="Application Service"/>
+    <element xsi:type="archimate:ApplicationComponent" name="Application Component" id="4e337ab3"/>
+    <element xsi:type="archimate:ApplicationCollaboration" name="Application Collaboration" id="a3965597"/>
+    <element xsi:type="archimate:ApplicationInterface" name="Application Interface" id="72abc76d"/>
+    <element xsi:type="archimate:ApplicationService" name="Application Service" id="e5504f30"/>
+    <element xsi:type="archimate:ApplicationFunction" name="Application Function" id="9b0af2d9"/>
+    <element xsi:type="archimate:ApplicationInteraction" name="Application Interaction" id="51eecad7"/>
+    <element xsi:type="archimate:DataObject" name="Data Object" id="75a63568"/>
+    <element xsi:type="archimate:ApplicationComponent" name="Application Component" id="2f331587"/>
+    <element xsi:type="archimate:ApplicationInterface" name="Application Interface" id="8b0269a0"/>
+    <element xsi:type="archimate:ApplicationService" name="Application Service" id="c50ea139"/>
   </folder>
-  <folder name="Technology" id="a74c539b" type="technology">
-    <element xsi:type="archimate:Artifact" id="a58c2cff" name="Artifact that I found one day"/>
-    <element xsi:type="archimate:CommunicationPath" id="61b2ebb6" name="Communication Path"/>
-    <element xsi:type="archimate:Network" id="b55b532f" name="Network"/>
-    <element xsi:type="archimate:InfrastructureInterface" id="f5bb4733" name="Infrastructure Interface"/>
-    <element xsi:type="archimate:InfrastructureFunction" id="c3b8630a" name="Infrastructure Function"/>
-    <element xsi:type="archimate:InfrastructureService" id="1637e896" name="Infrastructure Service"/>
-    <element xsi:type="archimate:Node" id="7eacfc0f" name="Node"/>
-    <element xsi:type="archimate:SystemSoftware" id="5d63c4ac" name="System Software"/>
-    <element xsi:type="archimate:Device" id="78f8493b" name="Device"/>
-    <element xsi:type="archimate:InfrastructureInterface" id="7d72249a" name="Infrastructure Interface"/>
-    <element xsi:type="archimate:InfrastructureService" id="a11b9eb7" name="Infrastructure Service"/>
-    <element xsi:type="archimate:Node" id="fa48c0eb" name="Node"/>
-    <element xsi:type="archimate:Device" id="89d89ded" name="Device"/>
+  <folder name="Technology &amp; Physical" id="a74c539b" type="technology">
+    <element xsi:type="archimate:Artifact" name="Artifact that I found one day" id="a58c2cff"/>
+    <element xsi:type="archimate:Path" name="Communication Path" id="61b2ebb6"/>
+    <element xsi:type="archimate:CommunicationNetwork" name="Network" id="b55b532f"/>
+    <element xsi:type="archimate:TechnologyInterface" name="Infrastructure Interface" id="f5bb4733"/>
+    <element xsi:type="archimate:TechnologyFunction" name="Infrastructure Function" id="c3b8630a"/>
+    <element xsi:type="archimate:TechnologyService" name="Infrastructure Service" id="1637e896"/>
+    <element xsi:type="archimate:Node" name="Node" id="7eacfc0f"/>
+    <element xsi:type="archimate:SystemSoftware" name="System Software" id="5d63c4ac"/>
+    <element xsi:type="archimate:Device" name="Device" id="78f8493b"/>
+    <element xsi:type="archimate:TechnologyInterface" name="Infrastructure Interface" id="7d72249a"/>
+    <element xsi:type="archimate:TechnologyService" name="Infrastructure Service" id="a11b9eb7"/>
+    <element xsi:type="archimate:Node" name="Node" id="fa48c0eb"/>
+    <element xsi:type="archimate:Device" name="Device" id="89d89ded"/>
   </folder>
   <folder name="Motivation" id="408765be" type="motivation">
-    <element xsi:type="archimate:Stakeholder" id="1ef2b6b0" name="Stakeholder"/>
-    <element xsi:type="archimate:Driver" id="49f1b964" name="Driver"/>
-    <element xsi:type="archimate:Assessment" id="21876b7e" name="Assessment"/>
-    <element xsi:type="archimate:Goal" id="35d27705" name="Goal"/>
-    <element xsi:type="archimate:Principle" id="4a1a1a71" name="Principle"/>
-    <element xsi:type="archimate:Requirement" id="529a4b14" name="Requirement"/>
-    <element xsi:type="archimate:Constraint" id="da7394bd" name="Constraint"/>
+    <element xsi:type="archimate:Stakeholder" name="Stakeholder" id="1ef2b6b0"/>
+    <element xsi:type="archimate:Driver" name="Driver" id="49f1b964"/>
+    <element xsi:type="archimate:Assessment" name="Assessment" id="21876b7e"/>
+    <element xsi:type="archimate:Goal" name="Goal" id="35d27705"/>
+    <element xsi:type="archimate:Principle" name="Principle" id="4a1a1a71"/>
+    <element xsi:type="archimate:Requirement" name="Requirement" id="529a4b14"/>
+    <element xsi:type="archimate:Constraint" name="Constraint" id="da7394bd"/>
+    <element xsi:type="archimate:Value" name="Value of some thing" id="5ce14ef5"/>
+    <element xsi:type="archimate:Meaning" name="Meaning" id="b9d8f495"/>
   </folder>
   <folder name="Implementation &amp; Migration" id="8d93ba4e" type="implementation_migration">
-    <element xsi:type="archimate:WorkPackage" id="77fa0664" name="Work Package"/>
-    <element xsi:type="archimate:Deliverable" id="0e8739c2" name="Deliverable"/>
-    <element xsi:type="archimate:Plateau" id="d89ba03a" name="Plateau"/>
-    <element xsi:type="archimate:Gap" id="9005d244" name="Gap"/>
+    <element xsi:type="archimate:WorkPackage" name="Work Package" id="77fa0664"/>
+    <element xsi:type="archimate:Deliverable" name="Deliverable" id="0e8739c2"/>
+    <element xsi:type="archimate:Plateau" name="Plateau" id="d89ba03a"/>
+    <element xsi:type="archimate:Gap" name="Gap" id="9005d244"/>
   </folder>
-  <folder name="Connectors" id="9c7368b7" type="connectors">
-    <element xsi:type="archimate:Junction" id="1bbf9386" name="Junction"/>
-    <element xsi:type="archimate:AndJunction" id="2b5667ad" name="And Junction"/>
-    <element xsi:type="archimate:OrJunction" id="a3344375" name="Or Junction"/>
+  <folder name="Other" id="35ffba9f-5aad-4820-a37a-2e548f4c5124" type="other">
+    <element xsi:type="archimate:Junction" name="Junction" id="1bbf9386"/>
+    <element xsi:type="archimate:Junction" name="And Junction" id="2b5667ad"/>
+    <element xsi:type="archimate:Junction" name="Or Junction" id="a3344375"/>
+    <element xsi:type="archimate:Location" name="Location" id="d8440883"/>
+    <element xsi:type="archimate:Grouping" name="Grouping" id="5f48a3fc-7864-4e9e-ac2b-3f6f1e6a0344"/>
   </folder>
   <folder name="Relations" id="5db30097" type="relations">
-    <element xsi:type="archimate:InfluenceRelationship" id="56731509" source="21876b7e" target="35d27705"/>
-    <element xsi:type="archimate:SpecialisationRelationship" id="4e16546f" source="fa48c0eb" target="7eacfc0f"/>
+    <element xsi:type="archimate:InfluenceRelationship" id="56731509" source="21876b7e" target="35d27705" strength="++"/>
+    <element xsi:type="archimate:SpecializationRelationship" id="4e16546f" source="fa48c0eb" target="7eacfc0f"/>
     <element xsi:type="archimate:CompositionRelationship" id="c8c82c51" source="495250a2" target="b5dd94c9"/>
     <element xsi:type="archimate:AggregationRelationship" id="c8a3de09" source="11af7615" target="bc1ceb46"/>
     <element xsi:type="archimate:AssignmentRelationship" id="060a4402" source="895b5ec5" target="d1a45f58"/>
-    <element xsi:type="archimate:RealisationRelationship" id="c181b0c6" source="15e2172c" target="b5dd94c9"/>
+    <element xsi:type="archimate:RealizationRelationship" id="c181b0c6" source="15e2172c" target="b5dd94c9"/>
     <element xsi:type="archimate:TriggeringRelationship" id="065064e2" source="cfffd652" target="2a00fdf3"/>
     <element xsi:type="archimate:FlowRelationship" id="43c00467" source="2a00fdf3" target="a3965597"/>
     <element xsi:type="archimate:AssociationRelationship" id="d1290848" source="61b2ebb6" target="b55b532f"/>
     <element xsi:type="archimate:AccessRelationship" id="277e36e1" source="15e2172c" target="03064f37"/>
-    <element xsi:type="archimate:UsedByRelationship" id="03bc5201" source="4e337ab3" target="e5504f30"/>
+    <element xsi:type="archimate:ServingRelationship" id="03bc5201" source="4e337ab3" target="e5504f30"/>
     <element xsi:type="archimate:FlowRelationship" id="d9cb9327" source="70630355" target="1bbf9386"/>
     <element xsi:type="archimate:FlowRelationship" id="2111dd5e" source="1bbf9386" target="d393c534"/>
     <element xsi:type="archimate:FlowRelationship" id="6e0561fa" source="70630355" target="a3344375"/>
@@ -93,9 +95,13 @@
     <element xsi:type="archimate:FlowRelationship" id="06a30a60" source="1bbf9386" target="867c2f22"/>
     <element xsi:type="archimate:FlowRelationship" id="1316e37d" source="867c2f22" target="2b5667ad"/>
     <element xsi:type="archimate:TriggeringRelationship" id="17250bc3" source="2b5667ad" target="890c6b06"/>
+    <element xsi:type="archimate:AssociationRelationship" id="12deff83-a003-4f4e-9a1a-79c8aafd3e5e" source="f123a9d3" target="06a30a60"/>
+    <element xsi:type="archimate:CompositionRelationship" id="01497e63-4bef-4e9b-b6b2-2b5af4852d34" source="5f48a3fc-7864-4e9e-ac2b-3f6f1e6a0344" target="5ce14ef5"/>
+    <element xsi:type="archimate:CompositionRelationship" id="02d26023-f8cb-490c-96ba-874577e3257e" source="d8440883" target="1316e37d"/>
+    <element xsi:type="archimate:AggregationRelationship" id="fff0a41d-b5c5-4546-b56c-2f3c4ec411de" source="5f48a3fc-7864-4e9e-ac2b-3f6f1e6a0344" target="1316e37d"/>
   </folder>
   <folder name="Views" id="dc1827ec" type="diagrams">
-    <element xsi:type="archimate:ArchimateDiagramModel" id="3b1325ab" name="Everything">
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Everything" id="3b1325ab">
       <child xsi:type="archimate:Note" id="58beed2f" fontColor="#ffffff" textAlignment="1" fillColor="#19b5d1">
         <bounds x="21" y="12" width="185" height="80"/>
         <content>This file contains an example of all elements.
@@ -104,215 +110,231 @@
       <child xsi:type="archimate:Group" id="659c77c0" name="Some Group" fillColor="#ff7f00">
         <bounds x="228" y="12" width="400" height="140"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="6eed0efe" textAlignment="2" archimateElement="895b5ec5">
+      <child xsi:type="archimate:DiagramObject" id="6eed0efe" archimateElement="895b5ec5">
         <bounds x="34" y="192" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="a861bf86" source="6eed0efe" target="9f690b26" relationship="060a4402"/>
+        <sourceConnection xsi:type="archimate:Connection" id="a861bf86" source="6eed0efe" target="9f690b26" archimateRelationship="060a4402"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="9f690b26" textAlignment="2" targetConnections="a861bf86" archimateElement="d1a45f58">
+      <child xsi:type="archimate:DiagramObject" id="9f690b26" targetConnections="a861bf86" archimateElement="d1a45f58">
         <bounds x="211" y="192" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="85dda01b" textAlignment="2" archimateElement="b6677ae1">
+      <child xsi:type="archimate:DiagramObject" id="85dda01b" archimateElement="b6677ae1">
         <bounds x="432" y="192" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="2eaa0159" textAlignment="2" targetConnections="6479ad7c" archimateElement="bc1ceb46">
+      <child xsi:type="archimate:DiagramObject" id="2eaa0159" targetConnections="6479ad7c" archimateElement="bc1ceb46">
         <bounds x="622" y="192" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="bca054d4" textAlignment="2" archimateElement="15e2172c">
+      <child xsi:type="archimate:DiagramObject" id="bca054d4" archimateElement="15e2172c">
         <bounds x="805" y="192" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="3deef271" source="bca054d4" target="6c5e730c" relationship="c181b0c6"/>
-        <sourceConnection xsi:type="archimate:Connection" id="286b6bc8" source="bca054d4" target="9343d930" relationship="277e36e1"/>
+        <sourceConnection xsi:type="archimate:Connection" id="3deef271" source="bca054d4" target="6c5e730c" archimateRelationship="c181b0c6"/>
+        <sourceConnection xsi:type="archimate:Connection" id="286b6bc8" source="bca054d4" target="9343d930" archimateRelationship="277e36e1"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="05776ea0" textAlignment="2" archimateElement="70630355">
+      <child xsi:type="archimate:DiagramObject" id="05776ea0" archimateElement="70630355">
         <bounds x="970" y="192" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="1799a957" source="05776ea0" target="88d4451b" relationship="d9cb9327"/>
-        <sourceConnection xsi:type="archimate:Connection" id="d56a2161" source="05776ea0" target="b022b466" relationship="6e0561fa"/>
+        <sourceConnection xsi:type="archimate:Connection" id="1799a957" source="05776ea0" target="88d4451b" archimateRelationship="d9cb9327"/>
+        <sourceConnection xsi:type="archimate:Connection" id="d56a2161" source="05776ea0" target="b022b466" archimateRelationship="6e0561fa"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="d35cbea1" textAlignment="2" archimateElement="cfffd652">
+      <child xsi:type="archimate:DiagramObject" id="d35cbea1" archimateElement="cfffd652" type="1">
         <bounds x="34" y="396" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="18b4ca69" source="d35cbea1" target="cd7891a1" relationship="065064e2"/>
+        <sourceConnection xsi:type="archimate:Connection" id="18b4ca69" source="d35cbea1" target="cd7891a1" archimateRelationship="065064e2"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="cd7891a1" textAlignment="2" targetConnections="18b4ca69" archimateElement="2a00fdf3">
+      <child xsi:type="archimate:DiagramObject" id="cd7891a1" targetConnections="18b4ca69" archimateElement="2a00fdf3">
         <bounds x="211" y="396" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="c636eb3b" source="cd7891a1" target="266a9baf" relationship="43c00467">
+        <sourceConnection xsi:type="archimate:Connection" id="c636eb3b" source="cd7891a1" target="266a9baf" archimateRelationship="43c00467">
           <bendpoint startX="114" startY="-2" endX="114" endY="-244"/>
           <bendpoint startX="114" startY="238" endX="114" endY="-4"/>
         </sourceConnection>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="690c932f" textAlignment="2" archimateElement="f0090d70">
+      <child xsi:type="archimate:DiagramObject" id="690c932f" archimateElement="f0090d70">
         <bounds x="432" y="396" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="9343d930" textAlignment="2" targetConnections="286b6bc8" archimateElement="03064f37">
+      <child xsi:type="archimate:DiagramObject" id="9343d930" targetConnections="286b6bc8" archimateElement="03064f37">
         <bounds x="622" y="396" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="6c5e730c" textAlignment="2" targetConnections="515af364 3deef271" archimateElement="b5dd94c9">
+      <child xsi:type="archimate:DiagramObject" id="6c5e730c" targetConnections="515af364 3deef271" archimateElement="b5dd94c9">
         <bounds x="805" y="396" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="984507e1" textAlignment="2" archimateElement="5ce14ef5">
-        <bounds x="970" y="396" width="120" height="55"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="7dfe60d0" textAlignment="2" archimateElement="b9d8f495">
+      <child xsi:type="archimate:DiagramObject" id="7dfe60d0" archimateElement="b9d8f495">
         <bounds x="34" y="540" width="123" height="41"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="9d73afb1" textAlignment="2" archimateElement="ab4c4726">
+      <child xsi:type="archimate:DiagramObject" id="9d73afb1" archimateElement="ab4c4726">
         <bounds x="211" y="521" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="b5fa2aa5" textAlignment="2" archimateElement="e1616652">
+      <child xsi:type="archimate:DiagramObject" id="b5fa2aa5" archimateElement="e1616652">
         <bounds x="432" y="527" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="680f7206" textAlignment="2" archimateElement="d8440883">
-        <bounds x="622" y="519" width="120" height="55"/>
+      <child xsi:type="archimate:DiagramObject" id="680f7206" archimateElement="d8440883">
+        <bounds x="1284" y="396" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7a523a2e-a882-4c2e-96ed-3d1b3d1a2e24" source="680f7206" target="2c2b5b6f" archimateRelationship="02d26023-f8cb-490c-96ba-874577e3257e"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="6c6845d7" textAlignment="2" archimateElement="4e337ab3">
+      <child xsi:type="archimate:DiagramObject" id="6c6845d7" archimateElement="4e337ab3">
         <bounds x="34" y="635" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="2b5f9753" source="6c6845d7" target="97d38439" relationship="03bc5201">
+        <sourceConnection xsi:type="archimate:Connection" id="2b5f9753" source="6c6845d7" target="97d38439" archimateRelationship="03bc5201">
           <bendpoint startX="14" startY="46" endX="-574" endY="46"/>
           <bendpoint startX="590" startY="46" endX="2" endY="46"/>
         </sourceConnection>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="266a9baf" textAlignment="2" targetConnections="c636eb3b" archimateElement="a3965597">
+      <child xsi:type="archimate:DiagramObject" id="266a9baf" targetConnections="c636eb3b" archimateElement="a3965597">
         <bounds x="211" y="637" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="81b9f0a3" textAlignment="2" archimateElement="72abc76d">
+      <child xsi:type="archimate:DiagramObject" id="81b9f0a3" archimateElement="72abc76d">
         <bounds x="432" y="638" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="97d38439" textAlignment="2" targetConnections="2b5f9753" archimateElement="e5504f30">
+      <child xsi:type="archimate:DiagramObject" id="97d38439" targetConnections="2b5f9753" archimateElement="e5504f30">
         <bounds x="622" y="635" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="260ca9ad" textAlignment="2" archimateElement="9b0af2d9">
+      <child xsi:type="archimate:DiagramObject" id="260ca9ad" archimateElement="9b0af2d9">
         <bounds x="805" y="636" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="53e42a10" textAlignment="2" archimateElement="51eecad7">
+      <child xsi:type="archimate:DiagramObject" id="53e42a10" archimateElement="51eecad7">
         <bounds x="970" y="628" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="e47a0cd4" textAlignment="2" archimateElement="75a63568">
+      <child xsi:type="archimate:DiagramObject" id="e47a0cd4" archimateElement="75a63568">
         <bounds x="1158" y="631" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="42932d19" textAlignment="2" archimateElement="a58c2cff">
+      <child xsi:type="archimate:DiagramObject" id="42932d19" archimateElement="a58c2cff">
         <bounds x="34" y="858" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="3c3a988a" textAlignment="2" archimateElement="61b2ebb6">
+      <child xsi:type="archimate:DiagramObject" id="3c3a988a" archimateElement="61b2ebb6">
         <bounds x="211" y="864" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="5bd78e7f" source="3c3a988a" target="417dab02" relationship="d1290848"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5bd78e7f" source="3c3a988a" target="417dab02" archimateRelationship="d1290848"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="417dab02" textAlignment="2" targetConnections="5bd78e7f" archimateElement="b55b532f">
+      <child xsi:type="archimate:DiagramObject" id="417dab02" targetConnections="5bd78e7f" archimateElement="b55b532f">
         <bounds x="432" y="866" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="3c495109" textAlignment="2" archimateElement="f5bb4733">
+      <child xsi:type="archimate:DiagramObject" id="3c495109" archimateElement="f5bb4733">
         <bounds x="622" y="864" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="9acf80e6" textAlignment="2" archimateElement="c3b8630a">
+      <child xsi:type="archimate:DiagramObject" id="9acf80e6" archimateElement="c3b8630a">
         <bounds x="805" y="861" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="869f27f8" textAlignment="2" archimateElement="1637e896">
+      <child xsi:type="archimate:DiagramObject" id="869f27f8" archimateElement="1637e896">
         <bounds x="970" y="863" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="32e5c347" textAlignment="2" targetConnections="6a64cda8" archimateElement="7eacfc0f">
+      <child xsi:type="archimate:DiagramObject" id="32e5c347" targetConnections="6a64cda8" archimateElement="7eacfc0f">
         <bounds x="34" y="1072" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="e6b8f0cc" textAlignment="2" archimateElement="5d63c4ac">
+      <child xsi:type="archimate:DiagramObject" id="e6b8f0cc" archimateElement="5d63c4ac">
         <bounds x="211" y="1070" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="f5afad73" textAlignment="2" archimateElement="78f8493b">
+      <child xsi:type="archimate:DiagramObject" id="f5afad73" archimateElement="78f8493b">
         <bounds x="432" y="1068" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="2c725ae1" textAlignment="2" archimateElement="1ef2b6b0">
+      <child xsi:type="archimate:DiagramObject" id="2c725ae1" archimateElement="1ef2b6b0">
         <bounds x="34" y="1281" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="39715fa7" textAlignment="2" archimateElement="49f1b964">
+      <child xsi:type="archimate:DiagramObject" id="39715fa7" archimateElement="49f1b964">
         <bounds x="211" y="1281" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="cb41a33f" textAlignment="2" archimateElement="21876b7e">
+      <child xsi:type="archimate:DiagramObject" id="cb41a33f" archimateElement="21876b7e">
         <bounds x="432" y="1281" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="be22a316" source="cb41a33f" target="fe4fa2e5" relationship="56731509"/>
+        <sourceConnection xsi:type="archimate:Connection" id="be22a316" source="cb41a33f" target="fe4fa2e5" archimateRelationship="56731509"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="fe4fa2e5" textAlignment="2" targetConnections="be22a316" archimateElement="35d27705">
+      <child xsi:type="archimate:DiagramObject" id="fe4fa2e5" targetConnections="be22a316" archimateElement="35d27705">
         <bounds x="622" y="1281" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="3aa3e8de" textAlignment="2" archimateElement="4a1a1a71">
+      <child xsi:type="archimate:DiagramObject" id="3aa3e8de" archimateElement="4a1a1a71">
         <bounds x="805" y="1281" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="2fa6412b" textAlignment="2" archimateElement="529a4b14">
+      <child xsi:type="archimate:DiagramObject" id="2fa6412b" archimateElement="529a4b14">
         <bounds x="970" y="1281" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="48ce1d7b" textAlignment="2" archimateElement="da7394bd">
+      <child xsi:type="archimate:DiagramObject" id="48ce1d7b" archimateElement="da7394bd">
         <bounds x="1158" y="1281" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="0e596689" textAlignment="2" archimateElement="77fa0664">
+      <child xsi:type="archimate:DiagramObject" id="0e596689" archimateElement="77fa0664">
         <bounds x="34" y="1411" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="7700d50c" textAlignment="2" archimateElement="0e8739c2">
+      <child xsi:type="archimate:DiagramObject" id="7700d50c" archimateElement="0e8739c2">
         <bounds x="205" y="1411" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="eb025fe1" textAlignment="2" archimateElement="d89ba03a">
+      <child xsi:type="archimate:DiagramObject" id="eb025fe1" archimateElement="d89ba03a">
         <bounds x="432" y="1411" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="a962d96b" textAlignment="2" archimateElement="9005d244">
+      <child xsi:type="archimate:DiagramObject" id="a962d96b" archimateElement="9005d244">
         <bounds x="622" y="1411" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="5af24699" textAlignment="2" archimateElement="11af7615" type="1">
+      <child xsi:type="archimate:DiagramObject" id="5af24699" archimateElement="11af7615" type="1">
         <bounds x="622" y="300" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="6479ad7c" source="5af24699" target="2eaa0159" relationship="c8a3de09"/>
+        <sourceConnection xsi:type="archimate:Connection" id="6479ad7c" source="5af24699" target="2eaa0159" archimateRelationship="c8a3de09"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="036fe300" textAlignment="2" targetConnections="3f75488b" archimateElement="d393c534" type="1">
+      <child xsi:type="archimate:DiagramObject" id="036fe300" targetConnections="3f75488b" archimateElement="d393c534" type="1">
         <bounds x="970" y="300" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="905f1ff1" textAlignment="2" archimateElement="495250a2" type="1">
+      <child xsi:type="archimate:DiagramObject" id="905f1ff1" archimateElement="495250a2" type="1">
         <bounds x="804" y="519" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="515af364" source="905f1ff1" target="6c5e730c" relationship="c8c82c51"/>
+        <sourceConnection xsi:type="archimate:Connection" id="515af364" source="905f1ff1" target="6c5e730c" archimateRelationship="c8c82c51"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="42090901" textAlignment="2" archimateElement="2f331587" type="1">
+      <child xsi:type="archimate:DiagramObject" id="42090901" archimateElement="2f331587" type="1">
         <bounds x="34" y="732" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="02906bef" textAlignment="2" archimateElement="8b0269a0" type="1">
+      <child xsi:type="archimate:DiagramObject" id="02906bef" archimateElement="8b0269a0" type="1">
         <bounds x="432" y="732" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="054d8190" textAlignment="2" archimateElement="c50ea139" type="1">
+      <child xsi:type="archimate:DiagramObject" id="054d8190" archimateElement="c50ea139" type="1">
         <bounds x="622" y="732" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="47e70e34" textAlignment="2" archimateElement="7d72249a" type="1">
+      <child xsi:type="archimate:DiagramObject" id="47e70e34" archimateElement="7d72249a" type="1">
         <bounds x="622" y="948" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="909b4ae7" textAlignment="2" archimateElement="a11b9eb7" type="1">
+      <child xsi:type="archimate:DiagramObject" id="909b4ae7" archimateElement="a11b9eb7" type="1">
         <bounds x="970" y="948" width="120" height="55"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="efcac28b" textAlignment="2" archimateElement="fa48c0eb" type="1">
+      <child xsi:type="archimate:DiagramObject" id="efcac28b" archimateElement="fa48c0eb" type="1">
         <bounds x="34" y="1152" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="6a64cda8" source="efcac28b" target="32e5c347" relationship="4e16546f"/>
+        <sourceConnection xsi:type="archimate:Connection" id="6a64cda8" source="efcac28b" target="32e5c347" archimateRelationship="4e16546f"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="6fbb9d3c" textAlignment="2" archimateElement="89d89ded" type="1">
+      <child xsi:type="archimate:DiagramObject" id="6fbb9d3c" archimateElement="89d89ded" type="1">
         <bounds x="432" y="1152" width="120" height="55"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="f6f74fda" font="1|Comic Sans MS|14.0|0|COCOA|1|ComicSansMS" fontColor="#ffffff" textAlignment="4" fillColor="#ff0000" archimateElement="f123a9d3">
-        <bounds x="1158" y="396" width="120" height="55"/>
+        <bounds x="1068" y="408" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5c4f750b-d82b-40a2-bc68-1882162bb4ec" source="f6f74fda" target="d6d42eda" archimateRelationship="12deff83-a003-4f4e-9a1a-79c8aafd3e5e"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="88d4451b" targetConnections="1799a957" archimateElement="1bbf9386">
         <bounds x="1016" y="268" width="15" height="15"/>
-        <sourceConnection xsi:type="archimate:Connection" id="3f75488b" source="88d4451b" target="036fe300" relationship="2111dd5e"/>
-        <sourceConnection xsi:type="archimate:Connection" id="d6d42eda" source="88d4451b" target="b7ba03c5" relationship="06a30a60"/>
+        <sourceConnection xsi:type="archimate:Connection" id="3f75488b" source="88d4451b" target="036fe300" archimateRelationship="2111dd5e"/>
+        <sourceConnection xsi:type="archimate:Connection" id="d6d42eda" targetConnections="5c4f750b-d82b-40a2-bc68-1882162bb4ec" source="88d4451b" target="b7ba03c5" archimateRelationship="06a30a60"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="efa16c3e" textAlignment="2" targetConnections="8e7705d6" archimateElement="e7c1a5f3">
+      <child xsi:type="archimate:DiagramObject" id="efa16c3e" targetConnections="8e7705d6" archimateElement="e7c1a5f3">
         <bounds x="1284" y="151" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="f4659084" source="efa16c3e" target="237a19de" relationship="1a162973">
+        <sourceConnection xsi:type="archimate:Connection" id="f4659084" source="efa16c3e" target="237a19de" archimateRelationship="1a162973">
           <bendpoint startX="168" startY="2" endX="-6" endY="-56"/>
         </sourceConnection>
       </child>
       <child xsi:type="archimate:DiagramObject" id="237a19de" targetConnections="f4659084 2c2b5b6f" archimateElement="2b5667ad">
         <bounds x="1512" y="230" width="15" height="15"/>
-        <sourceConnection xsi:type="archimate:Connection" id="cb9c5e49" source="237a19de" target="81d78be9" relationship="17250bc3"/>
+        <sourceConnection xsi:type="archimate:Connection" id="cb9c5e49" source="237a19de" target="81d78be9" archimateRelationship="17250bc3"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="b022b466" targetConnections="d56a2161" archimateElement="a3344375">
         <bounds x="1176" y="216" width="15" height="15"/>
-        <sourceConnection xsi:type="archimate:Connection" id="8e7705d6" source="b022b466" target="efa16c3e" relationship="6f36fe71"/>
-        <sourceConnection xsi:type="archimate:Connection" id="bc8ac527" source="b022b466" target="b7ba03c5" relationship="0f76942c"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8e7705d6" source="b022b466" target="efa16c3e" archimateRelationship="6f36fe71"/>
+        <sourceConnection xsi:type="archimate:Connection" id="bc8ac527" source="b022b466" target="b7ba03c5" archimateRelationship="0f76942c"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="b7ba03c5" textAlignment="2" targetConnections="bc8ac527 d6d42eda" archimateElement="867c2f22">
+      <child xsi:type="archimate:DiagramObject" id="b7ba03c5" targetConnections="bc8ac527 d6d42eda" archimateElement="867c2f22">
         <bounds x="1284" y="244" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="2c2b5b6f" source="b7ba03c5" target="237a19de" relationship="1316e37d">
+        <sourceConnection xsi:type="archimate:Connection" id="2c2b5b6f" targetConnections="7a523a2e-a882-4c2e-96ed-3d1b3d1a2e24 59882fbd-534c-4a4b-b6ae-0a0eae078114" source="b7ba03c5" target="237a19de" archimateRelationship="1316e37d">
           <bendpoint startX="180" startY="6" endX="6" endY="40"/>
         </sourceConnection>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="81d78be9" textAlignment="2" targetConnections="cb9c5e49" archimateElement="890c6b06">
+      <child xsi:type="archimate:DiagramObject" id="81d78be9" targetConnections="cb9c5e49" archimateElement="890c6b06">
         <bounds x="1610" y="222" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="4965e136-8eaa-4fe8-9e6b-af3e761e12b1" archimateElement="5f48a3fc-7864-4e9e-ac2b-3f6f1e6a0344">
+        <bounds x="1464" y="396" width="194" height="122"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ffa9778f-10ce-4d7a-af2b-238b24b88d29" source="4965e136-8eaa-4fe8-9e6b-af3e761e12b1" target="984507e1" archimateRelationship="01497e63-4bef-4e9b-b6b2-2b5af4852d34"/>
+        <sourceConnection xsi:type="archimate:Connection" id="59882fbd-534c-4a4b-b6ae-0a0eae078114" source="4965e136-8eaa-4fe8-9e6b-af3e761e12b1" target="2c2b5b6f" archimateRelationship="fff0a41d-b5c5-4546-b56c-2f3c4ec411de"/>
+        <child xsi:type="archimate:DiagramObject" id="984507e1" targetConnections="ffa9778f-10ce-4d7a-af2b-238b24b88d29" archimateElement="5ce14ef5">
+          <bounds x="24" y="36" width="120" height="55"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramModelReference" id="886821b0-0435-4934-9355-a4d57c3dad2b" model="e0d837de-1ad4-4677-9112-fedf0d46aa07">
+        <bounds x="1452" y="638" width="120" height="55"/>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Referenced By Everything" id="e0d837de-1ad4-4677-9112-fedf0d46aa07">
+      <child xsi:type="archimate:Note" id="d5bde945-0089-4ab5-8fdb-6ea981518b5a" textAlignment="1">
+        <bounds x="69" y="74" width="185" height="80"/>
+        <content>This diagram is referenced via link by the Everything diagram.</content>
       </child>
     </element>
   </folder>

--- a/test/examples/everything.xml
+++ b/test/examples/everything.xml
@@ -1,0 +1,860 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model xmlns="http://www.opengroup.org/xsd/archimate/3.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengroup.org/xsd/archimate/3.0/ http://www.opengroup.org/xsd/archimate/3.0/archimate3_Diagram.xsd" identifier="id-1d703f78">
+  <name xml:lang="en">everything</name>
+  <elements>
+    <element identifier="id-895b5ec5" xsi:type="BusinessActor">
+      <name xml:lang="en">Business Actor</name>
+    </element>
+    <element identifier="id-d1a45f58" xsi:type="BusinessRole">
+      <name xml:lang="en">Business Role</name>
+    </element>
+    <element identifier="id-b6677ae1" xsi:type="BusinessCollaboration">
+      <name xml:lang="en">Business Collaboration</name>
+    </element>
+    <element identifier="id-bc1ceb46" xsi:type="BusinessInterface">
+      <name xml:lang="en">Business Interface</name>
+    </element>
+    <element identifier="id-15e2172c" xsi:type="BusinessFunction">
+      <name xml:lang="en">Business Function</name>
+    </element>
+    <element identifier="id-70630355" xsi:type="BusinessProcess">
+      <name xml:lang="en">Business Process</name>
+    </element>
+    <element identifier="id-cfffd652" xsi:type="BusinessEvent">
+      <name xml:lang="en">Business Event</name>
+    </element>
+    <element identifier="id-2a00fdf3" xsi:type="BusinessInteraction">
+      <name xml:lang="en">Business Interaction</name>
+    </element>
+    <element identifier="id-f0090d70" xsi:type="Product">
+      <name xml:lang="en">Product</name>
+    </element>
+    <element identifier="id-03064f37" xsi:type="Contract">
+      <name xml:lang="en">Contract</name>
+    </element>
+    <element identifier="id-b5dd94c9" xsi:type="BusinessService">
+      <name xml:lang="en">Business Service</name>
+    </element>
+    <element identifier="id-ab4c4726" xsi:type="Representation">
+      <name xml:lang="en">Representation of us and all of that</name>
+    </element>
+    <element identifier="id-e1616652" xsi:type="BusinessObject">
+      <name xml:lang="en">Business Object</name>
+    </element>
+    <element identifier="id-11af7615" xsi:type="BusinessInterface">
+      <name xml:lang="en">Business Interface</name>
+    </element>
+    <element identifier="id-d393c534" xsi:type="BusinessProcess">
+      <name xml:lang="en">Business Process</name>
+    </element>
+    <element identifier="id-495250a2" xsi:type="BusinessService">
+      <name xml:lang="en">Business Service</name>
+    </element>
+    <element identifier="id-f123a9d3" xsi:type="BusinessActor">
+      <name xml:lang="en">Business Actor</name>
+    </element>
+    <element identifier="id-e7c1a5f3" xsi:type="BusinessProcess">
+      <name xml:lang="en">Business Process</name>
+    </element>
+    <element identifier="id-867c2f22" xsi:type="BusinessProcess">
+      <name xml:lang="en">Business Process</name>
+    </element>
+    <element identifier="id-890c6b06" xsi:type="BusinessEvent">
+      <name xml:lang="en">Business Event hello red fish blue fish</name>
+    </element>
+    <element identifier="id-4e337ab3" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Application Component</name>
+    </element>
+    <element identifier="id-a3965597" xsi:type="ApplicationCollaboration">
+      <name xml:lang="en">Application Collaboration</name>
+    </element>
+    <element identifier="id-72abc76d" xsi:type="ApplicationInterface">
+      <name xml:lang="en">Application Interface</name>
+    </element>
+    <element identifier="id-e5504f30" xsi:type="ApplicationService">
+      <name xml:lang="en">Application Service</name>
+    </element>
+    <element identifier="id-9b0af2d9" xsi:type="ApplicationFunction">
+      <name xml:lang="en">Application Function</name>
+    </element>
+    <element identifier="id-51eecad7" xsi:type="ApplicationInteraction">
+      <name xml:lang="en">Application Interaction</name>
+    </element>
+    <element identifier="id-75a63568" xsi:type="DataObject">
+      <name xml:lang="en">Data Object</name>
+    </element>
+    <element identifier="id-2f331587" xsi:type="ApplicationComponent">
+      <name xml:lang="en">Application Component</name>
+    </element>
+    <element identifier="id-8b0269a0" xsi:type="ApplicationInterface">
+      <name xml:lang="en">Application Interface</name>
+    </element>
+    <element identifier="id-c50ea139" xsi:type="ApplicationService">
+      <name xml:lang="en">Application Service</name>
+    </element>
+    <element identifier="id-a58c2cff" xsi:type="Artifact">
+      <name xml:lang="en">Artifact that I found one day</name>
+    </element>
+    <element identifier="id-61b2ebb6" xsi:type="Path">
+      <name xml:lang="en">Communication Path</name>
+    </element>
+    <element identifier="id-b55b532f" xsi:type="CommunicationNetwork">
+      <name xml:lang="en">Network</name>
+    </element>
+    <element identifier="id-f5bb4733" xsi:type="TechnologyInterface">
+      <name xml:lang="en">Infrastructure Interface</name>
+    </element>
+    <element identifier="id-c3b8630a" xsi:type="TechnologyFunction">
+      <name xml:lang="en">Infrastructure Function</name>
+    </element>
+    <element identifier="id-1637e896" xsi:type="TechnologyService">
+      <name xml:lang="en">Infrastructure Service</name>
+    </element>
+    <element identifier="id-7eacfc0f" xsi:type="Node">
+      <name xml:lang="en">Node</name>
+    </element>
+    <element identifier="id-5d63c4ac" xsi:type="SystemSoftware">
+      <name xml:lang="en">System Software</name>
+    </element>
+    <element identifier="id-78f8493b" xsi:type="Device">
+      <name xml:lang="en">Device</name>
+    </element>
+    <element identifier="id-7d72249a" xsi:type="TechnologyInterface">
+      <name xml:lang="en">Infrastructure Interface</name>
+    </element>
+    <element identifier="id-a11b9eb7" xsi:type="TechnologyService">
+      <name xml:lang="en">Infrastructure Service</name>
+    </element>
+    <element identifier="id-fa48c0eb" xsi:type="Node">
+      <name xml:lang="en">Node</name>
+    </element>
+    <element identifier="id-89d89ded" xsi:type="Device">
+      <name xml:lang="en">Device</name>
+    </element>
+    <element identifier="id-1ef2b6b0" xsi:type="Stakeholder">
+      <name xml:lang="en">Stakeholder</name>
+    </element>
+    <element identifier="id-49f1b964" xsi:type="Driver">
+      <name xml:lang="en">Driver</name>
+    </element>
+    <element identifier="id-21876b7e" xsi:type="Assessment">
+      <name xml:lang="en">Assessment</name>
+    </element>
+    <element identifier="id-35d27705" xsi:type="Goal">
+      <name xml:lang="en">Goal</name>
+    </element>
+    <element identifier="id-4a1a1a71" xsi:type="Principle">
+      <name xml:lang="en">Principle</name>
+    </element>
+    <element identifier="id-529a4b14" xsi:type="Requirement">
+      <name xml:lang="en">Requirement</name>
+    </element>
+    <element identifier="id-da7394bd" xsi:type="Constraint">
+      <name xml:lang="en">Constraint</name>
+    </element>
+    <element identifier="id-5ce14ef5" xsi:type="Value">
+      <name xml:lang="en">Value of some thing</name>
+    </element>
+    <element identifier="id-b9d8f495" xsi:type="Meaning">
+      <name xml:lang="en">Meaning</name>
+    </element>
+    <element identifier="id-77fa0664" xsi:type="WorkPackage">
+      <name xml:lang="en">Work Package</name>
+    </element>
+    <element identifier="id-0e8739c2" xsi:type="Deliverable">
+      <name xml:lang="en">Deliverable</name>
+    </element>
+    <element identifier="id-d89ba03a" xsi:type="Plateau">
+      <name xml:lang="en">Plateau</name>
+    </element>
+    <element identifier="id-9005d244" xsi:type="Gap">
+      <name xml:lang="en">Gap</name>
+    </element>
+    <element identifier="id-1bbf9386" xsi:type="AndJunction">
+      <name xml:lang="en">Junction</name>
+    </element>
+    <element identifier="id-2b5667ad" xsi:type="AndJunction">
+      <name xml:lang="en">And Junction</name>
+    </element>
+    <element identifier="id-a3344375" xsi:type="AndJunction">
+      <name xml:lang="en">Or Junction</name>
+    </element>
+    <element identifier="id-d8440883" xsi:type="Location">
+      <name xml:lang="en">Location</name>
+    </element>
+    <element identifier="id-5f48a3fc-7864-4e9e-ac2b-3f6f1e6a0344" xsi:type="Grouping">
+      <name xml:lang="en">Grouping</name>
+    </element>
+  </elements>
+  <relationships>
+    <relationship identifier="id-56731509" source="id-21876b7e" target="id-35d27705" xsi:type="Influence" modifier="++" />
+    <relationship identifier="id-4e16546f" source="id-fa48c0eb" target="id-7eacfc0f" xsi:type="Specialization" />
+    <relationship identifier="id-c8c82c51" source="id-495250a2" target="id-b5dd94c9" xsi:type="Composition" />
+    <relationship identifier="id-c8a3de09" source="id-11af7615" target="id-bc1ceb46" xsi:type="Aggregation" />
+    <relationship identifier="id-060a4402" source="id-895b5ec5" target="id-d1a45f58" xsi:type="Assignment" />
+    <relationship identifier="id-c181b0c6" source="id-15e2172c" target="id-b5dd94c9" xsi:type="Realization" />
+    <relationship identifier="id-065064e2" source="id-cfffd652" target="id-2a00fdf3" xsi:type="Triggering" />
+    <relationship identifier="id-43c00467" source="id-2a00fdf3" target="id-a3965597" xsi:type="Flow" />
+    <relationship identifier="id-d1290848" source="id-61b2ebb6" target="id-b55b532f" xsi:type="Association" />
+    <relationship identifier="id-277e36e1" source="id-15e2172c" target="id-03064f37" xsi:type="Access" accessType="Write" />
+    <relationship identifier="id-03bc5201" source="id-4e337ab3" target="id-e5504f30" xsi:type="Serving" />
+    <relationship identifier="id-d9cb9327" source="id-70630355" target="id-1bbf9386" xsi:type="Flow" />
+    <relationship identifier="id-2111dd5e" source="id-1bbf9386" target="id-d393c534" xsi:type="Flow" />
+    <relationship identifier="id-6e0561fa" source="id-70630355" target="id-a3344375" xsi:type="Flow" />
+    <relationship identifier="id-6f36fe71" source="id-a3344375" target="id-e7c1a5f3" xsi:type="Flow" />
+    <relationship identifier="id-0f76942c" source="id-a3344375" target="id-867c2f22" xsi:type="Flow" />
+    <relationship identifier="id-1a162973" source="id-e7c1a5f3" target="id-2b5667ad" xsi:type="Flow" />
+    <relationship identifier="id-06a30a60" source="id-1bbf9386" target="id-867c2f22" xsi:type="Flow" />
+    <relationship identifier="id-1316e37d" source="id-867c2f22" target="id-2b5667ad" xsi:type="Flow" />
+    <relationship identifier="id-17250bc3" source="id-2b5667ad" target="id-890c6b06" xsi:type="Triggering" />
+    <relationship identifier="id-12deff83-a003-4f4e-9a1a-79c8aafd3e5e" source="id-f123a9d3" target="id-06a30a60" xsi:type="Association" />
+    <relationship identifier="id-01497e63-4bef-4e9b-b6b2-2b5af4852d34" source="id-5f48a3fc-7864-4e9e-ac2b-3f6f1e6a0344" target="id-5ce14ef5" xsi:type="Composition" />
+    <relationship identifier="id-02d26023-f8cb-490c-96ba-874577e3257e" source="id-d8440883" target="id-1316e37d" xsi:type="Composition" />
+    <relationship identifier="id-fff0a41d-b5c5-4546-b56c-2f3c4ec411de" source="id-5f48a3fc-7864-4e9e-ac2b-3f6f1e6a0344" target="id-1316e37d" xsi:type="Aggregation" />
+  </relationships>
+  <organizations>
+    <item>
+      <label xml:lang="en">Business</label>
+      <item identifierRef="id-895b5ec5" />
+      <item identifierRef="id-d1a45f58" />
+      <item identifierRef="id-b6677ae1" />
+      <item identifierRef="id-bc1ceb46" />
+      <item identifierRef="id-15e2172c" />
+      <item identifierRef="id-70630355" />
+      <item identifierRef="id-cfffd652" />
+      <item identifierRef="id-2a00fdf3" />
+      <item identifierRef="id-f0090d70" />
+      <item identifierRef="id-03064f37" />
+      <item identifierRef="id-b5dd94c9" />
+      <item identifierRef="id-ab4c4726" />
+      <item identifierRef="id-e1616652" />
+      <item identifierRef="id-11af7615" />
+      <item identifierRef="id-d393c534" />
+      <item identifierRef="id-495250a2" />
+      <item identifierRef="id-f123a9d3" />
+      <item identifierRef="id-e7c1a5f3" />
+      <item identifierRef="id-867c2f22" />
+      <item identifierRef="id-890c6b06" />
+    </item>
+    <item>
+      <label xml:lang="en">Application</label>
+      <item identifierRef="id-4e337ab3" />
+      <item identifierRef="id-a3965597" />
+      <item identifierRef="id-72abc76d" />
+      <item identifierRef="id-e5504f30" />
+      <item identifierRef="id-9b0af2d9" />
+      <item identifierRef="id-51eecad7" />
+      <item identifierRef="id-75a63568" />
+      <item identifierRef="id-2f331587" />
+      <item identifierRef="id-8b0269a0" />
+      <item identifierRef="id-c50ea139" />
+    </item>
+    <item>
+      <label xml:lang="en">Technology &amp; Physical</label>
+      <item identifierRef="id-a58c2cff" />
+      <item identifierRef="id-61b2ebb6" />
+      <item identifierRef="id-b55b532f" />
+      <item identifierRef="id-f5bb4733" />
+      <item identifierRef="id-c3b8630a" />
+      <item identifierRef="id-1637e896" />
+      <item identifierRef="id-7eacfc0f" />
+      <item identifierRef="id-5d63c4ac" />
+      <item identifierRef="id-78f8493b" />
+      <item identifierRef="id-7d72249a" />
+      <item identifierRef="id-a11b9eb7" />
+      <item identifierRef="id-fa48c0eb" />
+      <item identifierRef="id-89d89ded" />
+    </item>
+    <item>
+      <label xml:lang="en">Motivation</label>
+      <item identifierRef="id-1ef2b6b0" />
+      <item identifierRef="id-49f1b964" />
+      <item identifierRef="id-21876b7e" />
+      <item identifierRef="id-35d27705" />
+      <item identifierRef="id-4a1a1a71" />
+      <item identifierRef="id-529a4b14" />
+      <item identifierRef="id-da7394bd" />
+      <item identifierRef="id-5ce14ef5" />
+      <item identifierRef="id-b9d8f495" />
+    </item>
+    <item>
+      <label xml:lang="en">Implementation &amp; Migration</label>
+      <item identifierRef="id-77fa0664" />
+      <item identifierRef="id-0e8739c2" />
+      <item identifierRef="id-d89ba03a" />
+      <item identifierRef="id-9005d244" />
+    </item>
+    <item>
+      <label xml:lang="en">Other</label>
+      <item identifierRef="id-1bbf9386" />
+      <item identifierRef="id-2b5667ad" />
+      <item identifierRef="id-a3344375" />
+      <item identifierRef="id-d8440883" />
+      <item identifierRef="id-5f48a3fc-7864-4e9e-ac2b-3f6f1e6a0344" />
+    </item>
+    <item>
+      <label xml:lang="en">Relations</label>
+      <item identifierRef="id-56731509" />
+      <item identifierRef="id-4e16546f" />
+      <item identifierRef="id-c8c82c51" />
+      <item identifierRef="id-c8a3de09" />
+      <item identifierRef="id-060a4402" />
+      <item identifierRef="id-c181b0c6" />
+      <item identifierRef="id-065064e2" />
+      <item identifierRef="id-43c00467" />
+      <item identifierRef="id-d1290848" />
+      <item identifierRef="id-277e36e1" />
+      <item identifierRef="id-03bc5201" />
+      <item identifierRef="id-d9cb9327" />
+      <item identifierRef="id-2111dd5e" />
+      <item identifierRef="id-6e0561fa" />
+      <item identifierRef="id-6f36fe71" />
+      <item identifierRef="id-0f76942c" />
+      <item identifierRef="id-1a162973" />
+      <item identifierRef="id-06a30a60" />
+      <item identifierRef="id-1316e37d" />
+      <item identifierRef="id-17250bc3" />
+      <item identifierRef="id-12deff83-a003-4f4e-9a1a-79c8aafd3e5e" />
+      <item identifierRef="id-01497e63-4bef-4e9b-b6b2-2b5af4852d34" />
+      <item identifierRef="id-02d26023-f8cb-490c-96ba-874577e3257e" />
+      <item identifierRef="id-fff0a41d-b5c5-4546-b56c-2f3c4ec411de" />
+    </item>
+    <item>
+      <label xml:lang="en">Views</label>
+      <item identifierRef="id-3b1325ab" />
+      <item identifierRef="id-e0d837de-1ad4-4677-9112-fedf0d46aa07" />
+    </item>
+  </organizations>
+  <views>
+    <diagrams>
+      <view identifier="id-3b1325ab" xsi:type="Diagram">
+        <name xml:lang="en">Everything</name>
+        <node identifier="id-58beed2f" xsi:type="Label" x="21" y="12" w="185" h="80">
+          <label xml:lang="en">This file contains an example of all elements.</label>
+          <style>
+            <fillColor r="25" g="181" b="209" />
+            <lineColor r="92" g="92" b="92" />
+            <font>
+              <color r="255" g="255" b="255" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-659c77c0" x="228" y="12" w="400" h="140" xsi:type="Container">
+          <label xml:lang="en">Some Group</label>
+          <style>
+            <fillColor r="255" g="127" b="0" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-6eed0efe" elementRef="id-895b5ec5" xsi:type="Element" x="34" y="192" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-9f690b26" elementRef="id-d1a45f58" xsi:type="Element" x="211" y="192" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-85dda01b" elementRef="id-b6677ae1" xsi:type="Element" x="432" y="192" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-2eaa0159" elementRef="id-bc1ceb46" xsi:type="Element" x="622" y="192" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-bca054d4" elementRef="id-15e2172c" xsi:type="Element" x="805" y="192" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-05776ea0" elementRef="id-70630355" xsi:type="Element" x="970" y="192" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-d35cbea1" elementRef="id-cfffd652" xsi:type="Element" x="34" y="396" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-cd7891a1" elementRef="id-2a00fdf3" xsi:type="Element" x="211" y="396" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-690c932f" elementRef="id-f0090d70" xsi:type="Element" x="432" y="396" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-9343d930" elementRef="id-03064f37" xsi:type="Element" x="622" y="396" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-6c5e730c" elementRef="id-b5dd94c9" xsi:type="Element" x="805" y="396" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-7dfe60d0" elementRef="id-b9d8f495" xsi:type="Element" x="34" y="540" w="123" h="41">
+          <style>
+            <fillColor r="204" g="204" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-9d73afb1" elementRef="id-ab4c4726" xsi:type="Element" x="211" y="521" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-b5fa2aa5" elementRef="id-e1616652" xsi:type="Element" x="432" y="527" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-680f7206" elementRef="id-d8440883" xsi:type="Element" x="1284" y="396" w="120" h="55">
+          <style>
+            <fillColor r="251" g="184" b="117" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-6c6845d7" elementRef="id-4e337ab3" xsi:type="Element" x="34" y="635" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-266a9baf" elementRef="id-a3965597" xsi:type="Element" x="211" y="637" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-81b9f0a3" elementRef="id-72abc76d" xsi:type="Element" x="432" y="638" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-97d38439" elementRef="id-e5504f30" xsi:type="Element" x="622" y="635" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-260ca9ad" elementRef="id-9b0af2d9" xsi:type="Element" x="805" y="636" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-53e42a10" elementRef="id-51eecad7" xsi:type="Element" x="970" y="628" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-e47a0cd4" elementRef="id-75a63568" xsi:type="Element" x="1158" y="631" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-42932d19" elementRef="id-a58c2cff" xsi:type="Element" x="34" y="858" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-3c3a988a" elementRef="id-61b2ebb6" xsi:type="Element" x="211" y="864" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-417dab02" elementRef="id-b55b532f" xsi:type="Element" x="432" y="866" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-3c495109" elementRef="id-f5bb4733" xsi:type="Element" x="622" y="864" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-9acf80e6" elementRef="id-c3b8630a" xsi:type="Element" x="805" y="861" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-869f27f8" elementRef="id-1637e896" xsi:type="Element" x="970" y="863" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-32e5c347" elementRef="id-7eacfc0f" xsi:type="Element" x="34" y="1072" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-e6b8f0cc" elementRef="id-5d63c4ac" xsi:type="Element" x="211" y="1070" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-f5afad73" elementRef="id-78f8493b" xsi:type="Element" x="432" y="1068" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-2c725ae1" elementRef="id-1ef2b6b0" xsi:type="Element" x="34" y="1281" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-39715fa7" elementRef="id-49f1b964" xsi:type="Element" x="211" y="1281" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-cb41a33f" elementRef="id-21876b7e" xsi:type="Element" x="432" y="1281" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-fe4fa2e5" elementRef="id-35d27705" xsi:type="Element" x="622" y="1281" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-3aa3e8de" elementRef="id-4a1a1a71" xsi:type="Element" x="805" y="1281" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-2fa6412b" elementRef="id-529a4b14" xsi:type="Element" x="970" y="1281" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-48ce1d7b" elementRef="id-da7394bd" xsi:type="Element" x="1158" y="1281" w="120" h="55">
+          <style>
+            <fillColor r="204" g="204" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-0e596689" elementRef="id-77fa0664" xsi:type="Element" x="34" y="1411" w="120" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-7700d50c" elementRef="id-0e8739c2" xsi:type="Element" x="205" y="1411" w="120" h="55">
+          <style>
+            <fillColor r="255" g="224" b="224" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-eb025fe1" elementRef="id-d89ba03a" xsi:type="Element" x="432" y="1411" w="120" h="55">
+          <style>
+            <fillColor r="224" g="255" b="224" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-a962d96b" elementRef="id-9005d244" xsi:type="Element" x="622" y="1411" w="120" h="55">
+          <style>
+            <fillColor r="224" g="255" b="224" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-5af24699" elementRef="id-11af7615" xsi:type="Element" x="622" y="300" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-036fe300" elementRef="id-d393c534" xsi:type="Element" x="970" y="300" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-905f1ff1" elementRef="id-495250a2" xsi:type="Element" x="804" y="519" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-42090901" elementRef="id-2f331587" xsi:type="Element" x="34" y="732" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-02906bef" elementRef="id-8b0269a0" xsi:type="Element" x="432" y="732" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-054d8190" elementRef="id-c50ea139" xsi:type="Element" x="622" y="732" w="120" h="55">
+          <style>
+            <fillColor r="181" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-47e70e34" elementRef="id-7d72249a" xsi:type="Element" x="622" y="948" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-909b4ae7" elementRef="id-a11b9eb7" xsi:type="Element" x="970" y="948" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-efcac28b" elementRef="id-fa48c0eb" xsi:type="Element" x="34" y="1152" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-6fbb9d3c" elementRef="id-89d89ded" xsi:type="Element" x="432" y="1152" w="120" h="55">
+          <style>
+            <fillColor r="201" g="231" b="183" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-f6f74fda" elementRef="id-f123a9d3" xsi:type="Element" x="1068" y="408" w="120" h="55">
+          <style>
+            <fillColor r="255" g="0" b="0" />
+            <lineColor r="92" g="92" b="92" />
+            <font name="Comic Sans MS" size="14">
+              <color r="255" g="255" b="255" />
+            </font>
+          </style>
+        </node>
+        <node identifier="id-88d4451b" elementRef="id-1bbf9386" xsi:type="Element" x="1016" y="268" w="15" h="15">
+          <style>
+            <fillColor r="0" g="0" b="0" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-efa16c3e" elementRef="id-e7c1a5f3" xsi:type="Element" x="1284" y="151" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-237a19de" elementRef="id-2b5667ad" xsi:type="Element" x="1512" y="230" w="15" h="15">
+          <style>
+            <fillColor r="0" g="0" b="0" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-b022b466" elementRef="id-a3344375" xsi:type="Element" x="1176" y="216" w="15" h="15">
+          <style>
+            <fillColor r="0" g="0" b="0" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-b7ba03c5" elementRef="id-867c2f22" xsi:type="Element" x="1284" y="244" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-81d78be9" elementRef="id-890c6b06" xsi:type="Element" x="1610" y="222" w="120" h="55">
+          <style>
+            <fillColor r="255" g="255" b="181" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+        <node identifier="id-4965e136-8eaa-4fe8-9e6b-af3e761e12b1" elementRef="id-5f48a3fc-7864-4e9e-ac2b-3f6f1e6a0344" xsi:type="Element" x="1464" y="396" w="194" h="122">
+          <style>
+            <fillColor r="255" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+          <node identifier="id-984507e1" elementRef="id-5ce14ef5" xsi:type="Element" x="1488" y="432" w="120" h="55">
+            <style>
+              <fillColor r="204" g="204" b="255" />
+              <lineColor r="92" g="92" b="92" />
+            </style>
+          </node>
+        </node>
+        <node identifier="id-886821b0-0435-4934-9355-a4d57c3dad2b" xsi:type="Label" x="1452" y="638" w="120" h="55">
+          <label xml:lang="en">Referenced By Everything</label>
+          <style>
+            <fillColor r="220" g="235" b="235" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+          <viewRef ref="id-e0d837de-1ad4-4677-9112-fedf0d46aa07" />
+        </node>
+        <connection identifier="id-a861bf86" relationshipRef="id-060a4402" xsi:type="Relationship" source="id-6eed0efe" target="id-9f690b26">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-3deef271" relationshipRef="id-c181b0c6" xsi:type="Relationship" source="id-bca054d4" target="id-6c5e730c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-286b6bc8" relationshipRef="id-277e36e1" xsi:type="Relationship" source="id-bca054d4" target="id-9343d930">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-1799a957" relationshipRef="id-d9cb9327" xsi:type="Relationship" source="id-05776ea0" target="id-88d4451b">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-d56a2161" relationshipRef="id-6e0561fa" xsi:type="Relationship" source="id-05776ea0" target="id-b022b466">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-18b4ca69" relationshipRef="id-065064e2" xsi:type="Relationship" source="id-d35cbea1" target="id-cd7891a1">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-c636eb3b" relationshipRef="id-43c00467" xsi:type="Relationship" source="id-cd7891a1" target="id-266a9baf">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+          <bendpoint x="385" y="420" />
+          <bendpoint x="385" y="660" />
+        </connection>
+        <connection identifier="id-7a523a2e-a882-4c2e-96ed-3d1b3d1a2e24" relationshipRef="id-02d26023-f8cb-490c-96ba-874577e3257e" xsi:type="Relationship" source="id-680f7206" target="id-2c2b5b6f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-2b5f9753" relationshipRef="id-03bc5201" xsi:type="Relationship" source="id-6c6845d7" target="id-97d38439">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+          <bendpoint x="108" y="708" />
+          <bendpoint x="684" y="708" />
+        </connection>
+        <connection identifier="id-5bd78e7f" relationshipRef="id-d1290848" xsi:type="Relationship" source="id-3c3a988a" target="id-417dab02">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-be22a316" relationshipRef="id-56731509" xsi:type="Relationship" source="id-cb41a33f" target="id-fe4fa2e5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-6479ad7c" relationshipRef="id-c8a3de09" xsi:type="Relationship" source="id-5af24699" target="id-2eaa0159">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-515af364" relationshipRef="id-c8c82c51" xsi:type="Relationship" source="id-905f1ff1" target="id-6c5e730c">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-6a64cda8" relationshipRef="id-4e16546f" xsi:type="Relationship" source="id-efcac28b" target="id-32e5c347">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-5c4f750b-d82b-40a2-bc68-1882162bb4ec" relationshipRef="id-12deff83-a003-4f4e-9a1a-79c8aafd3e5e" xsi:type="Relationship" source="id-f6f74fda" target="id-d6d42eda">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-3f75488b" relationshipRef="id-2111dd5e" xsi:type="Relationship" source="id-88d4451b" target="id-036fe300">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-d6d42eda" relationshipRef="id-06a30a60" xsi:type="Relationship" source="id-88d4451b" target="id-b7ba03c5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-f4659084" relationshipRef="id-1a162973" xsi:type="Relationship" source="id-efa16c3e" target="id-237a19de">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+          <bendpoint x="1512" y="180" />
+        </connection>
+        <connection identifier="id-cb9c5e49" relationshipRef="id-17250bc3" xsi:type="Relationship" source="id-237a19de" target="id-81d78be9">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-8e7705d6" relationshipRef="id-6f36fe71" xsi:type="Relationship" source="id-b022b466" target="id-efa16c3e">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-bc8ac527" relationshipRef="id-0f76942c" xsi:type="Relationship" source="id-b022b466" target="id-b7ba03c5">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+        <connection identifier="id-2c2b5b6f" relationshipRef="id-1316e37d" xsi:type="Relationship" source="id-b7ba03c5" target="id-237a19de">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+          <bendpoint x="1524" y="277" />
+        </connection>
+        <connection identifier="id-59882fbd-534c-4a4b-b6ae-0a0eae078114" relationshipRef="id-fff0a41d-b5c5-4546-b56c-2f3c4ec411de" xsi:type="Relationship" source="id-4965e136-8eaa-4fe8-9e6b-af3e761e12b1" target="id-2c2b5b6f">
+          <style>
+            <lineColor r="0" g="0" b="0" />
+          </style>
+        </connection>
+      </view>
+      <view identifier="id-e0d837de-1ad4-4677-9112-fedf0d46aa07" xsi:type="Diagram">
+        <name xml:lang="en">Referenced By Everything</name>
+        <node identifier="id-d5bde945-0089-4ab5-8fdb-6ea981518b5a" xsi:type="Label" x="69" y="74" w="185" h="80">
+          <label xml:lang="en">This diagram is referenced via link by the Everything diagram.</label>
+          <style>
+            <fillColor r="255" g="255" b="255" />
+            <lineColor r="92" g="92" b="92" />
+          </style>
+        </node>
+      </view>
+    </diagrams>
+  </views>
+</model>

--- a/test/integration/stats_test.rb
+++ b/test/integration/stats_test.rb
@@ -10,10 +10,10 @@ module Archimate
       end
       assert_empty err
       result = Color.uncolor(out)
-      assert_match(/Business *68\b/, result)
+      assert_match(/Business *67\b/, result)
       assert_match(/Application *22\b/, result)
       assert_match(/Technology *21\b/, result)
-      assert_match(/Motivation *9\b/, result)
+      assert_match(/Motivation *10\b/, result)
       assert_match(/Total Elements *120\b/, result)
       assert_match(/Relationships *178\b/, result)
       assert_match(/Diagrams *17\b/, result)
@@ -25,10 +25,10 @@ module Archimate
       end
       assert_empty err
       result = Color.uncolor(out)
-      assert_match(/Business *67\b/, result)
+      assert_match(/Business *66\b/, result)
       assert_match(/Application *25\b/, result)
       assert_match(/Technology *18\b/, result)
-      assert_match(/Motivation *9\b/, result)
+      assert_match(/Motivation *10\b/, result)
       assert_match(/Total Elements *119\b/, result)
       assert_match(/Relationships *179\b/, result)
       assert_match(/Diagrams *17\b/, result)

--- a/test/integration/svg_test.rb
+++ b/test/integration/svg_test.rb
@@ -16,5 +16,20 @@ module Archimate
         assert_equal expected_ids, actual_ids
       end
     end
+
+    def test_svg_all_elements_and_relationships
+      model = Archimate.read("test/examples/everything.archimate")
+      Dir.mktmpdir do |dir|
+        out, err = capture_io do
+          Cli::Archi.start ["svg", "-n", "-o", dir, "test/examples/everything.archimate"]
+        end
+        assert_empty out
+        assert_empty err
+        svgs = Dir.glob(File.join(dir, "*.svg"))
+        expected_ids = model.diagrams.map(&:id).sort
+        actual_ids = svgs.map { |name| File.basename(name, ".svg") }.sort
+        assert_equal expected_ids, actual_ids
+      end
+    end
   end
 end


### PR DESCRIPTION
This completes support for ArchiMate 3.0 model support.
Validated diagram generation against Archi tool.
Added support for Relationship->Relationship connection
Added support for alternate element representations

Addresses: 

* #27 Links between diagrams
* #6 ArchiMate 3.0 support.